### PR TITLE
i18n-friendly JS + English Language

### DIFF
--- a/src/chrome_extension/content/content.js
+++ b/src/chrome_extension/content/content.js
@@ -4,45 +4,16 @@ import './css/content.scss'
 import './css/nav.scss'
 import './css/kemo.scss'
 
-/**
- * head
- */
-const exHeadList = [
-  'すごーい！',
-  'すっごーい！',
-  'わーい！',
-]
-const preHeadList = [
-  'キミは',
-  'あなたは',
-]
-const postHeadList = [
-  'のフレンズなんだね！',
-  'って言うんだー！',
-]
+import language from './language.json';
 
-/**
- * paragraph
- */
-const postPeriodList = [
-  'すごーい',
-  'すっごーい',
-  'わーい！',
-  'たのしー！',
-  'たーのしー！',
-  'うー！がぉー！',
-  'へーきへーき！',
-  'なにこれー！？',
-]
-const postParaList = [
-  'でも騒ぐほどでもないか',
-  '全然知らなかったー',
-  'そうなのー！？',
-  'たべないよー！',
-  'そんなことないよー！',
-  'って言うんだー！',
-  '知ってたー?',
-]
+const words = (() => {
+  // Detect the language of the wiki page
+  switch (/https:\/\/(.*?).wiki/.exec(document.URL)[1]) {
+    case "en" : return language.en; break;
+    case "jp" : return language.jp; break;
+    default: return language.jp; break;
+  }
+})()
 
 const sayRate = 0.3
 
@@ -51,7 +22,7 @@ const randomPick = list => list[Math.floor(Math.random() * list.length)]
 const kemoInnerHTML = list => `<span class="kemo-say">＼${randomPick(list)}／</span>`
 
 const japarizeWikipedia = () => {
-  document.title = document.title.replace(/wikipedia$/i, 'ジャパリ図書館')
+  document.title = document.title.replace(/wikipedia$/i, words.title)
 
   const walker = document.createTreeWalker(
     document.body,
@@ -62,33 +33,31 @@ const japarizeWikipedia = () => {
 
   let n
   while ((n = walker.nextNode())) {
-    n.textContent = n.textContent.replace(/(wikipedia|ウィキペディア)/gi, 'ジャパリ図書館')
+    n.textContent = n.textContent.replace(/(wikipedia|ウィキペディア)/gi, words.title)
   }
 }
 
 const japarizeHeader = () => {
   document
   .querySelectorAll('.mw-headline, #mw-panel h3')
-  .forEach(el => (el.textContent = `ジャパリ${el.textContent}`))
+  .forEach(el => (el.textContent = words.titlemin + el.textContent))
 }
 
 const becomeFriendWithSectionTitle = () => {
   const head = document.getElementById('firstHeading')
   head.textContent = [
-    randomPick(exHeadList),
-    randomPick(preHeadList),
-    ' ',
+    randomPick(words.exHeadList),
+    randomPick(words.preHeadList),
     head.textContent,
-    ' ',
-    randomPick(postHeadList),
-  ].join('')
+    randomPick(words.postHeadList),
+  ].join(' ')
 }
 
 const insertWordsInContent = () => {
   document
   .querySelectorAll('#mw-content-text > p')
   .forEach((para) => {
-    let sentence = para.innerHTML.match(/.+?[。]/g)
+    let sentence = para.innerHTML.match(/(.+?[。]|.+?\. )(?!([^<]+)?>)/g)
     if (!sentence) {
       return
     }
@@ -97,13 +66,13 @@ const insertWordsInContent = () => {
     sentence = sentence
     .map((s, i) => (
       (i !== last && Math.random() < sayRate)
-        ? s + kemoInnerHTML(postPeriodList)
+        ? s + ' ' + kemoInnerHTML(words.postPeriodList)
         : s
       )
     )
 
     if (Math.random() < sayRate) {
-      sentence.push(kemoInnerHTML(postParaList))
+      sentence.push(' ' + kemoInnerHTML(words.postParaList))
     }
 
     para.innerHTML = sentence.join('')

--- a/src/chrome_extension/content/language.json
+++ b/src/chrome_extension/content/language.json
@@ -1,0 +1,92 @@
+{
+  "blank": {
+    "title": "",
+    "titlemin": "",
+    "exHeadList": [
+      ""
+    ],
+    "preHeadList": [
+      ""
+    ],
+    "postHeadList": [
+      ""
+    ],
+    "postPeriodList": [
+      ""
+    ],
+    "postParaList": [
+      ""
+    ]
+  },
+  "jp": {
+    "title": "ジャパリ図書館",
+    "titlemin": "ジャパリ",
+    "exHeadList": [
+      "すごーい！",
+      "すっごーい！",
+      "わーい！"
+    ],
+    "preHeadList": [
+      "キミは",
+      "あなたは"
+    ],
+    "postHeadList": [
+      "のフレンズなんだね！",
+      "って言うんだー！"
+    ],
+    "postPeriodList": [
+      "すごーい",
+      "すっごーい",
+      "わーい！",
+      "たのしー！",
+      "たーのしー！",
+      "うー！がぉー！",
+      "へーきへーき！",
+      "なにこれー！？"
+    ],
+    "postParaList": [
+      "でも騒ぐほどでもないか",
+      "全然知らなかったー",
+      "そうなのー！？",
+      "たべないよー！",
+      "そんなことないよー！",
+      "って言うんだー！",
+      "知ってたー?"
+    ]
+  },
+  "en": {
+    "title": "Japari Library ",
+    "titlemin": "Japari ",
+    "exHeadList": [
+      "Coool!",
+      "Cooooool!",
+      "Whoooa!"
+    ],
+    "preHeadList": [
+      "You're friends with",
+      "You're a friend of"
+    ],
+    "postHeadList": [
+      "now, too!",
+      "they said!"
+    ],
+    "postPeriodList": [
+      "Coool",
+      "Cooooool",
+      "Whoooa",
+      "How Fun!",
+      "So Fun!",
+      "Neat!",
+      "What the heck!?"
+    ],
+    "postParaList": [
+      "But it doesn't make a sound",
+      "I had no idea",
+      "Really!?",
+      "I can't eat that!",
+      "That's not true!",
+      "That's what they said!",
+      "Did you know that?"
+    ]
+  }
+}


### PR DESCRIPTION
This pull request should make it easier to add and change text in Japari-pedia. English Wikipedia pages should have English Japari text instead.

日本語よくできませんからすみません。これからi18n対応と英語があります。